### PR TITLE
[PMK-5665][PMK-5701 ] Remove network/disk alerts

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -36,16 +36,14 @@ spec:
         summary: PersistentVolume is filling up.
       expr: |-
         (
-          kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
-            /
-          kubelet_volume_stats_capacity_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
-        ) < 0.03
+          kubelet_volume_stats_available_bytes{job="kubelet",namespace=~".*"}
+          /
+          kubelet_volume_stats_capacity_bytes{job="kubelet",namespace=~".*"}
+        ) < 0.15
         and
-        kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+        kubelet_volume_stats_used_bytes{job="kubelet",namespace=~".*"} > 0
+        and
+        predict_linear(kubelet_volume_stats_available_bytes{job="kubelet",namespace=~".*"}[6h], 4 * 24 * 3600)
       for: 1m
       labels:
         severity: critical

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -208,40 +208,40 @@ spec:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}
-{{- if not (.Values.defaultRules.disabled.NodeNetworkReceiveErrs | default false) }}
-    - alert: NodeNetworkReceiveErrs
-      annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-        description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworkreceiveerrs
-        summary: Network interface is reporting many receive errors.
-      expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
-      for: 1h
-      labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-{{- end }}
-{{- if not (.Values.defaultRules.disabled.NodeNetworkTransmitErrs | default false) }}
-    - alert: NodeNetworkTransmitErrs
-      annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-        description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworktransmiterrs
-        summary: Network interface is reporting many transmit errors.
-      expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
-      for: 1h
-      labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-{{- end }}
+# {{- if not (.Values.defaultRules.disabled.NodeNetworkReceiveErrs | default false) }}
+#     - alert: NodeNetworkReceiveErrs
+#       annotations:
+# {{- if .Values.defaultRules.additionalRuleAnnotations }}
+# {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+# {{- end }}
+#         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
+#         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworkreceiveerrs
+#         summary: Network interface is reporting many receive errors.
+#       expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+#       for: 1h
+#       labels:
+#         severity: warning
+# {{- if .Values.defaultRules.additionalRuleLabels }}
+# {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+# {{- end }}
+# {{- end }}
+# {{- if not (.Values.defaultRules.disabled.NodeNetworkTransmitErrs | default false) }}
+#     - alert: NodeNetworkTransmitErrs
+#       annotations:
+# {{- if .Values.defaultRules.additionalRuleAnnotations }}
+# {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+# {{- end }}
+#         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
+#         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworktransmiterrs
+#         summary: Network interface is reporting many transmit errors.
+#       expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+#       for: 1h
+#       labels:
+#         severity: warning
+# {{- if .Values.defaultRules.additionalRuleLabels }}
+# {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+# {{- end }}
+# {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeHighNumberConntrackEntriesUsed | default false) }}
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -208,40 +208,6 @@ spec:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}
-# {{- if not (.Values.defaultRules.disabled.NodeNetworkReceiveErrs | default false) }}
-#     - alert: NodeNetworkReceiveErrs
-#       annotations:
-# {{- if .Values.defaultRules.additionalRuleAnnotations }}
-# {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-# {{- end }}
-#         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
-#         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworkreceiveerrs
-#         summary: Network interface is reporting many receive errors.
-#       expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
-#       for: 1h
-#       labels:
-#         severity: warning
-# {{- if .Values.defaultRules.additionalRuleLabels }}
-# {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-# {{- end }}
-# {{- end }}
-# {{- if not (.Values.defaultRules.disabled.NodeNetworkTransmitErrs | default false) }}
-#     - alert: NodeNetworkTransmitErrs
-#       annotations:
-# {{- if .Values.defaultRules.additionalRuleAnnotations }}
-# {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-# {{- end }}
-#         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
-#         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworktransmiterrs
-#         summary: Network interface is reporting many transmit errors.
-#       expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
-#       for: 1h
-#       labels:
-#         severity: warning
-# {{- if .Values.defaultRules.additionalRuleLabels }}
-# {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-# {{- end }}
-# {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeHighNumberConntrackEntriesUsed | default false) }}
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:


### PR DESCRIPTION
jira: https://platform9.atlassian.net/browse/PMK-5665

Removing below alerts
```
HostUnusualNetworkThroughputIn (0 active)
HostUnusualNetworkThroughputOut (0 active)
NodeNetworkReceiveErrs (0 active)
NodeNetworkTransmitErrs (0 active)
HostUnusualDiskWriteRate (0 active)
HostUnusualDiskReadRate (0 active)
```
Testing:


<img width="1245" alt="Screenshot 2023-04-17 at 4 52 01 PM" src="https://user-images.githubusercontent.com/51879259/232470435-ada858ca-431e-4275-b244-973b5096ea2a.png">



![Screenshot 2023-04-17 at 4 51 46 PM](https://user-images.githubusercontent.com/51879259/232470501-c8e7e16a-264d-4d70-b2a3-2f8e44967978.png)

