### PR TITLE
PMK-5815 Adding new alerts for monitoring pod restarts

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -42,6 +42,43 @@ spec:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}
+{{- if not (.Values.defaultRules.disabled.KubePodOOMKilled | default false) }}
+    - alert: KubePodOOMKilled
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }} --
+description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) has been OOMKilled.'
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodoomkilled
+        summary: Pod has been OOMKilled for more than 15 minutes.
+      expr: |-
+      count by (cluster,namespace,pod,container)(
+        kube_pod_container_status_last_terminated_reason{job='ksm', reason='OOMKilled'} offset 5m) > 0
+      for: 15m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.KubePodCrashLoopingThreshold | default false) }}
+    - alert: KubePodCrashLoopingThreshold
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }} --
+description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} in CrashLoopBackOff state, crossed the threshold value for restarts.
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodcrashloopingthreshold
+        summary: Number of Pod restarts has crossed the threshold value set for time-span of 15 minutes.
+      expr: |-
+      increase(kube_pod_container_status_restarts_total{job='ksm'}[15m] offset 5m) > 2
+      for: 15m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePodNotReady | default false) }}
     - alert: KubePodNotReady
       annotations:


### PR DESCRIPTION
## ISSUE(S):
[PMK-5815](https://platform9.atlassian.net/browse/PMK-5815)

## SUMMARY

Have added two new alerts, 
1) KubePodCrashLoopingThreshold: Checks the number of pod restarts in a span of 15 minutes, and if the number of restarts cross the threshold value, raises an alert.

2) KubePodOOMKilled: Checks if reason for termination was "OOMKilled", and if yes, raises an alert

## TESTING:

#### Manual
**Step 1**: Create a helm chart for private branch
```
helm package ./charts/kube-prometheus-stack --destination .deploy          
Successfully packaged chart and saved it to: .deploy/kube-prometheus-stack-38.0.8.tgz

ls .deploy
kube-prometheus-stack-38.0.8.tgz
```
**Step 2**: Install chart
```
helm install kube-prometheus-stack-38.0.2.tgz --generate-name
...
NAME: kube-prometheus-stack-38-1698226837
LAST DEPLOYED: Wed Oct 25 15:10:44 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES: 
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace pf9-monitoring get pods -l "release=kube-prometheus-stack-38-1698225074"

helm ls

NAME                               	NAMESPACE	REVISION	UPDATED                            	STATUS  	CHART                       APP VERSION
kube-prometheus-stack-38-1698226837	default  	1       	2023-10-25 15:10:44.29671 +0530 IST	deployed	kube-prometheus-stack-38.0.8 0.57.0     
```

**Step 3**: Verified all pods are running fine:

```
kubectl --namespace pf9-monitoring get pods -l "release=kube-prometheus-stack-38-1698226837"
NAME                                                              READY   STATUS    RESTARTS   AGE
kube-prometheus-stack-38-1698226837-kube-state-metrics-766jjbw7   1/1     Running   0          59m
kube-prometheus-stack-38-1698226837-prometheus-node-export2f9pc   1/1     Running   0          59m
kube-prometheus-stack-38-1698226837-prometheus-node-exportr6t5x   1/1     Running   0          59m
monhelper-76987bd888-dm6mn                                        1/1     Running   0          59m
pf9-prom-operator-79699b548b-k6bbc                                1/1     Running   0          59m
```

**Step 4**: Created a cluster and reduced the limits and requests for calico-typha to simulate OOMKilled.
```
kube-system            calico-typha-7566487986-t8zcp                                     0/1     OOMKilled   2 (21s ago)     39s
kube-system            calico-typha-autoscaler-54c8866496-jdt9s                          1/1     Running     0               2d10h
```
**Step 5**: Check promethes UI

a) Could see the "**KubePodOOMKilled**" alert firing.

<img width="1424" alt="Screenshot 2023-10-25 at 3 51 15 PM" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/025e7b31-15e3-4f9f-9829-8f074a0bf526">

b) Also the number of restarts of calico-typha had crossed the threshold value(2) in span of 15 minutes

<img width="1418" alt="image" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/4418c23e-5514-4653-84ef-3a15e38b61cd">

So could see the "**KubePodCrashloopingThreshold**" alert being fired as well:
<img width="1423" alt="Screenshot 2023-10-25 at 3 51 26 PM" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/a79981af-0db5-4050-b0d7-f54c6981fab3">

<img width="1422" alt="image" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/f7e8d043-da7b-42f4-9f7c-18f5eac39a05">

Later, reverted the limits to original ones and when calico-typha pod was running, could see the alerts go away.

[PMK-5815]: https://platform9.atlassian.net/browse/PMK-5815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ