### PR TITLE
Fix for newly added alerts

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -47,13 +47,11 @@ spec:
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }} --
-description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) has been OOMKilled.'
+{{- end }} 
+        description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) has been OOMKilled.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodoomkilled
         summary: Pod has been OOMKilled for more than 15 minutes.
-      expr: |-
-      count by (cluster,namespace,pod,container)(
-        kube_pod_container_status_last_terminated_reason{job='ksm', reason='OOMKilled'} offset 5m) > 0
+      expr: count by (cluster,namespace,pod,container)(kube_pod_container_status_last_terminated_reason{job='kube-state-metrics', reason='OOMKilled'} offset 5m) > 0
       for: 15m
       labels:
         severity: warning
@@ -66,12 +64,11 @@ description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }} --
-description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} in CrashLoopBackOff state, crossed the threshold value for restarts.
+{{- end }} 
+        description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} in CrashLoopBackOff state, crossed the threshold value for restarts.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodcrashloopingthreshold
         summary: Number of Pod restarts has crossed the threshold value set for time-span of 15 minutes.
-      expr: |-
-      increase(kube_pod_container_status_restarts_total{job='ksm'}[15m] offset 5m) > 2
+      expr: increase(kube_pod_container_status_restarts_total{job='kube-state-metrics'}[15m] offset 5m) > 2
       for: 15m
       labels:
         severity: warning


### PR DESCRIPTION
Missed out on a minor fix in PR: https://github.com/platform9/pf9-kube-prometheus-helm-chart/pull/5
Was facing this error:
```
Error: INSTALLATION FAILED: YAML parse error on kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml: error converting YAML to JSON: yaml: line 31: did not find expected key
```
With this fix able to install chart

```
helm package ./charts/kube-prometheus-stack --destination .deploy    
Successfully packaged chart and saved it to: .deploy/kube-prometheus-stack-38.0.3.tgz
manasab@FVFGQ3B0Q05P pf9-kube-prometheus-helm-chart % helm install .deploy/kube-prometheus-stack-38.0.3.tgz --generate-name

NAME: kube-prometheus-stack-38-1699002849
LAST DEPLOYED: Fri Nov  3 14:44:14 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace pf9-monitoring get pods -l "release=kube-prometheus-stack-38-1699002849"
```