### PR TITLE
PMK-6187 added skip verify for apiserver tls config

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2715,6 +2715,7 @@ prometheus:
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: endpoints


### PR DESCRIPTION
## ISSUE(S):
[PMK-6187](https://platform9.atlassian.net/browse/PMK-6187)

## SUMMARY

added `insecure_skip_verify: true` for apiserver job 

## TESTING:

#### Manual
```
helm package ./charts/kube-prometheus-stack --destination .deploy
Successfully packaged chart and saved it to: .deploy/kube-prometheus-stack-38.0.3.tgz

ls .deploy/
kube-prometheus-stack-38.0.3.tgz

helm install .deploy/kube-prometheus-stack-38.0.3.tgz --generate-name

NAME: kube-prometheus-stack-38-1699016251
LAST DEPLOYED: Fri Nov  3 12:57:32 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace pf9-monitoring get pods -l "release=kube-prometheus-stack-38-1699016251"
```
created cluster using `use hostname` and  installed above chart.

apiserver is up in prometheus ui. and there is no tls error here.

single master->

<img width="1158" alt="Screenshot 2023-11-03 at 6 07 41 PM" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/60594362/fa1d0743-0e6e-4490-b3a3-b5b3ae2e03de">

multi master ->

<img width="1148" alt="Screenshot 2023-11-03 at 8 47 13 PM" src="https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/60594362/4f8acfaf-e877-4259-afc9-048db5342bb0">



[PMK-6187]: https://platform9.atlassian.net/browse/PMK-6187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ