### PR TITLE
[PMK-6219] Fixing expression for KubePersistentVolumeErrors

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -60,4 +60,4 @@ sources:
 - https://github.com/prometheus-community/helm-charts
 - https://github.com/prometheus-operator/kube-prometheus
 type: application
-version: 52.1.0
+version: 52.1.1

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -193,7 +193,7 @@ spec:
         description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeerrors
         summary: PersistentVolume is having issues with provisioning.
-      expr: kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} >= 0
+      expr: kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
       for: 5m
       {{- with .Values.defaultRules.keepFiringFor }}
       keep_firing_for: "{{ . }}"


### PR DESCRIPTION
## ISSUE(S):
[PMK-6219](https://platform9.atlassian.net/browse/PMK-6219)

## SUMMARY:

False `KubePersistentVolumeErrors` Alerts were being generated due to a small issue with the expression. Fixed the expression

## TESTING:

Tested on a 1.26 cluster, installed pf9-kube-prometheus kube stack version 52.1.0. Created two sample PVs and PVCs. Even though the PVs weren't in Failed/Pending state, could see alerts firing for them
```
kc get pv
NAME   CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM           STORAGECLASS   REASON   AGE
pv-1   1Gi        RWX            Retain           Bound    default/pvc-1                           21m
pv-2   1Gi        RWX            Retain           Bound    default/pvc-2                           19m
```

![image](https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/de006edd-51c9-4a50-9b91-b02323b13f3b)
Here the value is 0, indicating that there are no PersistentVolumes in Pending/Failed state, still alert was being fired, hence rectified the alert expression

With this fix, could see that the alerts went away:

```
helm package ./charts/kube-prometheus-stack --destination .deploy
Successfully packaged chart and saved it to: .deploy/kube-prometheus-stack-52.1.1.tgz

helm upgrade --install testmon .deploy/kube-prometheus-stack-52.1.1.tgz 
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/manasab/test.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/manasab/test.yaml
Release "testmon" has been upgraded. Happy Helming!
NAME: testmon
LAST DEPLOYED: Wed Apr 10 15:15:01 2024
NAMESPACE: default
STATUS: deployed
REVISION: 2
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace pf9-monitoring get pods -l "release=testmon"

Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
```

```
kubectl  -n pf9-monitoring port-forward svc/pf9-prom-prometheus :9090
Forwarding from 127.0.0.1:58728 -> 9090
Forwarding from [::1]:58728 -> 9090
Handling connection for 58728
```

![image](https://github.com/platform9/pf9-kube-prometheus-helm-chart/assets/98585473/e19cb24a-53db-49c2-96c9-96d21067c91b)



[PMK-6219]: https://platform9.atlassian.net/browse/PMK-6219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ