### PR TITLE
[AIR-1458] update webhook_certgen to  v1.5.2

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2582,7 +2582,7 @@ prometheusOperator:
       image:
         registry: registry.k8s.io
         repository: ingress-nginx/kube-webhook-certgen
-        tag: v20221220-controller-v1.5.1-58-g787ea74b6
+        tag: v20221220-controller-v1.5.2
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}


### PR DESCRIPTION
https://platform9.atlassian.net/browse/AIR-1458

airctl nodelet images point to v1.5.2 : https://github.com/platform9/airctl/blob/platform9-v5.12/support/release/nodelet_image_list.txt#L27

