### PR TITLE
update certgen-webhook image

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2582,7 +2582,7 @@ prometheusOperator:
       image:
         registry: registry.k8s.io
         repository: ingress-nginx/kube-webhook-certgen
-        tag: v20221220-controller-v1.5.2
+        tag: v1.5.2
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}


### PR DESCRIPTION
updating image to v1.5.2 in main branch as well, since current tag is invalid.

backport for : https://github.com/platform9/pf9-kube-prometheus-helm-chart/pull/23