### PR TITLE
[PMK-6759] add metallb monitoring

### DIFF
--- a/charts/kube-prometheus-stack/grafana/grafana-dashboard-metallb
+++ b/charts/kube-prometheus-stack/grafana/grafana-dashboard-metallb
@@ -1,0 +1,1305 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Metallb dashboard https://metallb.universe.tf/  ",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 20162,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 83,
+      "panels": [],
+      "title": "Pool",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 229,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Total pool",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 230,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "IPv4 pool",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 231,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "IPv6 pool",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "<1%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 2
+      },
+      "id": 58,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.3.1",
+      "repeat": "pool",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(metallb_allocator_addresses_in_use_total{pool=~\"$pool\"}[$__rate_interval]) / last_over_time(metallb_allocator_addresses_total{pool=~\"$pool\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$pool",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "<1%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 3,
+        "y": 2
+      },
+      "id": 232,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.3.1",
+      "repeat": "pool",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(metallb_allocator_ipv4_addresses_in_use_total{pool=~\"$pool\"}[$__rate_interval]) / last_over_time(metallb_allocator_ipv4_addresses_total{pool=~\"$pool\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$pool",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "<1%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 6,
+        "y": 2
+      },
+      "id": 233,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.3.1",
+      "repeat": "pool",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(metallb_allocator_ipv6_addresses_in_use_total{pool=~\"$pool\"}[$__rate_interval]) / last_over_time(metallb_allocator_ipv6_addresses_total{pool=~\"$pool\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$pool",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 108,
+      "panels": [],
+      "title": "L2",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 158,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Gratuitous sent",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 159,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Requests received",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 160,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Responses sent",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "pps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 133,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "l2",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$l2\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "{{ ip }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$l2",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "pps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "id": 191,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "l2",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(metallb_layer2_requests_received{instance=~\"$l2\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "{{ip}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$l2",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "pps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 192,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "l2",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(metallb_layer2_responses_sent{instance=~\"$l2\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "{{ ip }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$l2",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Client metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 2,
+        "x": 0,
+        "y": 47
+      },
+      "id": 6,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Config loaded",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 2,
+        "x": 2,
+        "y": 47
+      },
+      "id": 7,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Config stale",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 10,
+        "x": 4,
+        "y": 47
+      },
+      "id": 4,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Client update",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 10,
+        "x": 14,
+        "y": 47
+      },
+      "id": 5,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.3.1",
+      "title": "Client update errors",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 2,
+        "x": 0,
+        "y": 48
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.1",
+      "repeat": "metallb_client",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "metallb_k8s_client_config_loaded_bool{instance=~\"$metallb_client\"}",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 2,
+        "x": 2,
+        "y": 48
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.1",
+      "repeat": "metallb_client",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "metallb_k8s_client_config_stale_bool{instance=~\"$metallb_client\"}",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 4,
+        "y": 48
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "metallb_client",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(metallb_k8s_client_updates_total{instance=~\"$metallb_client\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "$metallb_client",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 48
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "metallb_client",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(metallb_k8s_client_update_errors_total{instance=~\"$metallb_client\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "$metallb_client",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(metallb_allocator_addresses_in_use_total,pool)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(metallb_allocator_addresses_in_use_total,pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(metallb_layer2_gratuitous_sent,instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "l2",
+        "multi": true,
+        "name": "l2",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(metallb_layer2_gratuitous_sent,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(metallb_k8s_client_config_loaded_bool,instance)",
+        "description": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "metallb client",
+        "multi": true,
+        "name": "metallb_client",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(metallb_k8s_client_config_loaded_bool,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Metallb",
+  "uid": "fb5d0c21-344b-41e1-b342-d611f32b9fe4",
+  "version": 4,
+  "weekStart": ""
+}

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -318,3 +318,20 @@ global:
 {{ $fullname }}-webhook.{{ $namespace }}.svc
 {{- end }}
 {{- end }}
+
+{{- define "metallb.selectorKey" -}}
+{{- $deploy := lookup "apps/v1" "Deployment" "metallb-system" "metallb-controller" }}
+
+{{- if $deploy }}
+  {{- $labels := $deploy.spec.template.metadata.labels }}
+
+  {{- if hasKey $labels "app.kubernetes.io/component" }}
+app.kubernetes.io/component
+  {{- else }}
+component
+  {{- end }}
+
+{{- else }}
+component
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/metallb/_metallb_metrics_service.tpl
+++ b/charts/kube-prometheus-stack/templates/metallb/_metallb_metrics_service.tpl
@@ -1,0 +1,31 @@
+{{- define "metallb.metricsService" -}}
+
+{{- $root := .root }}
+{{- $name := .name }}
+{{- $component := .component }}
+
+{{- $svc := lookup "v1" "Service" "metallb-system" $name }}
+
+{{- if not $svc }}
+
+{{- $selectorKey := include "metallb.selectorKey" $root | trim }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  namespace: metallb-system
+  labels:
+    app: metallb
+    component: {{ $component }}
+spec:
+  ports:
+    - name: monitoring
+      port: 7472
+      targetPort: monitoring
+  selector:
+	{{- dict $selectorKey $component | toYaml | nindent 4 }}
+
+{{- end }}
+
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/metallb/metallb-metrics-services.yaml
+++ b/charts/kube-prometheus-stack/templates/metallb/metallb-metrics-services.yaml
@@ -1,0 +1,5 @@
+{{ include "metallb.metricsService" (dict "name" "metallb-controller-metrics" "component" "controller" "root" .) }}
+
+---
+
+{{ include "metallb.metricsService" (dict "name" "metallb-speaker-metrics" "component" "speaker" "root" .) }}

--- a/charts/kube-prometheus-stack/templates/metallb/prometheusrule.yaml
+++ b/charts/kube-prometheus-stack/templates/metallb/prometheusrule.yaml
@@ -1,0 +1,216 @@
+{{- if and .Values.metallb.enabled .Values.metallb.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "kube-prometheus-stack.fullname" . }}-metallb
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{ include "kube-prometheus-stack.labels" . | nindent 4 }}
+    component: metallb
+spec:
+  groups:
+    - name: metallb
+      interval: 30s
+      rules:
+
+          - alert: MetalLBStaleConfig
+            expr: metallb_k8s_client_config_stale_bool == 1
+            for: 1m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "Stale config on {{ `{{$labels.pod}}` }}"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has a stale config for > 1 minute.
+                This means the configuration has not been updated recently.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/staleconfig"
+
+          - alert: MetalLBConfigNotLoaded
+            expr: metallb_k8s_client_config_loaded_bool == 0
+            for: 1m
+            labels:
+              severity: critical
+              component: metallb
+            annotations:
+              summary: "Config on {{ `{{$labels.pod}}` }} has not been loaded"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has not loaded configuration for > 1 minute.
+                This is critical as the pod cannot function without a valid config.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/confignotloaded"
+
+          - alert: MetalLBAddressPoolExhausted
+            expr: metallb_allocator_addresses_in_use_total >= on(pool) metallb_allocator_addresses_total
+            for: 1m
+            labels:
+              severity: critical
+              component: metallb
+            annotations:
+              summary: "Address pool {{ `{{$labels.pool}}` }} exhausted on {{ `{{$labels.pod}}` }}"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has exhausted address pool {{ `{{$labels.pool}}` }} for > 1 minute.
+                No new LoadBalancer services can be provisioned until IPs are freed.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/poolexhausted"
+
+          - alert: MetalLBAddressPoolUsage90Percent
+            expr: |
+              (metallb_allocator_addresses_in_use_total
+               / on(pool) metallb_allocator_addresses_total) * 100 > 90
+            for: 1m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "Address pool {{ `{{$labels.pool}}` }} on {{ `{{$labels.pod}}` }} past 90% usage"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has address pool {{ `{{$labels.pool}}` }} at {{ `{{$value}}` }}% usage for > 1 minute.
+                Urgent action needed to avoid running out of IPs.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/poolusage90"
+
+          - alert: MetalLBAddressPoolUsage80Percent
+            expr: |
+              (metallb_allocator_addresses_in_use_total
+               / on(pool) metallb_allocator_addresses_total) * 100 > 80
+            for: 5m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "Address pool {{ `{{$labels.pool}}` }} on {{ `{{$labels.pod}}` }} at 80% usage"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has address pool {{ `{{$labels.pool}}` }} at {{ `{{$value}}` }}% usage.
+                Consider planning expansion of IP address pools.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/poolusage80"
+
+          - alert: MetalLBBGPSessionDown
+            expr: metallb_bgp_session_up == 0
+            for: 1m
+            labels:
+              severity: critical
+              component: metallb
+            annotations:
+              summary: "BGP session down on {{ `{{$labels.pod}}` }}"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                has BGP session {{ `{{$labels.peer}}` }} down for > 1 minute.
+                This means route advertisement to external networks is affected.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/bgpsessiondown"
+
+          - alert: MetalLBBGPSessionFlapping
+            expr: changes(metallb_bgp_session_up[5m]) > 3
+            for: 2m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "BGP session flapping on {{ `{{$labels.pod}}` }}"
+              description: |
+                MetalLB {{ `{{$labels.container}}` }} on {{ `{{$labels.pod}}` }}
+                BGP session {{ `{{$labels.peer}}` }} is flapping (changed state {{ `{{$value}}` }} times in 5m).
+                This indicates network instability.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/bgpflapping"
+
+          - alert: MetalLBControllerDown
+            expr: (sum(up{job="metallb-controller-metrics"}) == 0) or absent(up{job="metallb-controller-metrics"})
+            for: 5m
+            labels:
+              severity: critical
+              component: metallb
+            annotations:
+              summary: "MetalLB Controller is down"
+              description: |
+                MetalLB Controller pod is not responding for the last 5 minutes.
+                Address pool management and configuration updates will not work.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/controllerdown"
+
+          - alert: MetalLBSpeakerDown
+            expr: (sum(up{job="metallb-speaker-metrics"}) == 0) or absent(up{job="metallb-speaker-metrics"})
+            for: 5m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "MetalLB Speaker is down"
+              description: |
+                MetalLB Speaker pod is not responding for the last 5 minutes.
+                Route advertisement and protocol updates will not work on this node.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/speakerdown"
+
+          - alert: MetalLBL2AdvertisementFailures
+            expr: increase(metallb_l2_announce_total{result="error"}[5m]) > 0
+            for: 5m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "MetalLB L2 advertisement failures detected"
+              description: |
+                MetalLB encountered {{ `{{$value}}` }} L2 advertisement errors in the last 5 minutes.
+                Some LoadBalancer services may not be accessible via L2.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/l2advertisement"
+
+          - alert: MetalLBBFDSessionDown
+            expr: metallb_bfd_session_up == 0
+            for: 5m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "MetalLB BFD session is down"
+              description: |
+                MetalLB BFD session for peer {{ `{{$labels.peer}}` }} is down.
+                Fast failover detection for this peer is not working.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/bfdsessiondown"
+
+          - alert: MetalLBHighAllocationRate
+            expr: rate(metallb_allocator_addresses_in_use_total[5m]) > 0.1
+            for: 10m
+            labels:
+              severity: warning
+              component: metallb
+            annotations:
+              summary: "MetalLB allocating IPs at high rate"
+              description: |
+                Pool '{{ `{{$labels.pool}}` }}' is allocating IPs at {{ `{{$value}}` }}/sec.
+                Check for rapid service creation or leaks.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/highallocation"
+
+          - alert: MetalLBNoAdvertisements
+            expr: rate(metallb_advertised_total[5m]) == 0
+            for: 5m
+            labels:
+              severity: critical
+              component: metallb
+            annotations:
+              summary: "MetalLB is not advertising routes"
+              description: |
+                MetalLB on {{ `{{$labels.pod}}` }} is not advertising any routes.
+                LoadBalancer services will not be accessible externally.
+              runbook_url: "https://runbooks.prometheus-operator.dev/runbooks/metallb/noadvertisements"
+
+          - record: metallb:allocator:usage:percent
+            expr: |
+              (metallb_allocator_addresses_in_use_total
+               / on(pool) metallb_allocator_addresses_total) * 100
+            labels:
+              component: metallb
+
+          - record: metallb:bgp:session:uptime:hours
+            expr: |
+              (time() - metallb_bgp_session_uptime_seconds) / 3600
+            labels:
+              component: metallb
+
+          - record: metallb:controller:uptime:hours
+            expr: |
+              (time() - process_start_time_seconds{job="metallb-controller"}) / 3600
+            labels:
+              component: metallb
+
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/metallb/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/metallb/servicemonitor.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.metallb.enabled }}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ include "kube-prometheus-stack.fullname" . }}-metallb-servicemonitors
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+items:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: {{ include "kube-prometheus-stack.fullname" . }}-metallb-controller
+      namespace: {{ template "kube-prometheus-stack.namespace" . }}
+      labels:
+        app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+        {{ include "kube-prometheus-stack.labels" . | nindent 8 }}
+        component: metallb
+    spec:
+      selector:
+        matchLabels:
+          app: metallb
+          component: controller
+      namespaceSelector:
+        matchNames:
+          - metallb-system
+      endpoints:
+        - port: monitoring
+          interval: {{ .Values.metallb.serviceMonitor.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.metallb.serviceMonitor.scrapeTimeout | default "10s" }}
+          path: {{ .Values.metallb.serviceMonitor.path | default "/metrics" }}
+
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: {{ include "kube-prometheus-stack.fullname" . }}-metallb-speaker
+      namespace: {{ template "kube-prometheus-stack.namespace" . }}
+      labels:
+        app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+        {{ include "kube-prometheus-stack.labels" . | nindent 8 }}
+        component: metallb
+    spec:
+      selector:
+        matchLabels:
+          app: metallb
+          component: speaker
+      namespaceSelector:
+        matchNames:
+          - metallb-system
+      endpoints:
+        - port: monitoring
+          interval: {{ .Values.metallb.serviceMonitor.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.metallb.serviceMonitor.scrapeTimeout | default "10s" }}
+          path: {{ .Values.metallb.serviceMonitor.path | default "/metrics" }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1003,7 +1003,7 @@ grafana:
           url: https://raw.githubusercontent.com/platform9/pf9-kube-prometheus-helm-chart/main/charts/kube-prometheus-stack/grafana/grafana-dashboard-node-exporter
           token: ''
         metallb:
-          url: https://raw.githubusercontent.com/platform9/pf9-kube-prometheus-helm-chart/private/dc/main/pmk-6759/charts/kube-prometheus-stack/grafana/grafana-dashboard-metallb
+          url: https://raw.githubusercontent.com/platform9/pf9-kube-prometheus-helm-chart/main/charts/kube-prometheus-stack/grafana/grafana-dashboard-metallb
           token: ''
 #TODO change metallb dashboard url to point main branch instead of private.
 

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3941,7 +3941,7 @@ prometheus:
       honor_labels: false
       scheme: https
       tls_config:
-        insecure_skip_verify: true
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: node
@@ -3958,7 +3958,7 @@ prometheus:
       metrics_path: /metrics/cadvisor
       scheme: https
       tls_config:
-        insecure_skip_verify: true
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: node

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1002,6 +1002,10 @@ grafana:
         node-exporter:
           url: https://raw.githubusercontent.com/platform9/pf9-kube-prometheus-helm-chart/main/charts/kube-prometheus-stack/grafana/grafana-dashboard-node-exporter
           token: ''
+        metallb:
+          url: https://raw.githubusercontent.com/platform9/pf9-kube-prometheus-helm-chart/private/dc/main/pmk-6759/charts/kube-prometheus-stack/grafana/grafana-dashboard-metallb
+          token: ''
+#TODO change metallb dashboard url to point main branch instead of private.
 
   dashboardProviders:
      dashboardproviders.yaml:
@@ -2580,9 +2584,9 @@ prometheusOperator:
     patch:
       enabled: true
       image:
-        registry: registry.k8s.io
-        repository: ingress-nginx/kube-webhook-certgen
-        tag: v20221220-controller-v1.5.2
+        registry: v5cn
+        repository: ingress-nginx-kube-webhook-certgen
+        tag: v20221220-controller-v1.5.1-58-g787ea74b6
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}
@@ -4921,3 +4925,15 @@ extraManifests: []
   #     name: prometheus-extra
   #   data:
   #     extra-data: "value"
+
+# Metallb monitoring configuration
+metallb:
+  enabled: true
+
+  serviceMonitor:
+    interval: 30s
+    scrapeTimeout: 10s
+    path: /metrics
+
+  prometheusRule:
+    enabled: true

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2584,9 +2584,9 @@ prometheusOperator:
     patch:
       enabled: true
       image:
-        registry: v5cn
-        repository: ingress-nginx-kube-webhook-certgen
-        tag: v20221220-controller-v1.5.1-58-g787ea74b6
+        registry: registry.k8s.io
+        repository: ingress-nginx/kube-webhook-certgen
+        tag: v1.5.2
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}
@@ -3941,7 +3941,7 @@ prometheus:
       honor_labels: false
       scheme: https
       tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: node
@@ -3958,7 +3958,7 @@ prometheus:
       metrics_path: /metrics/cadvisor
       scheme: https
       tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: node


### PR DESCRIPTION
## Ticket:
https://platform9.atlassian.net/browse/PMK-6759

## Summary:
Add monitoring for metallb via kube-prometheus-stack helm chart.
Note: by default metallb will be monitored, set `metallb.enabled=false` for otherwise

## Testing:

### Metrics
<img width="1422" height="639" alt="Screenshot 2026-03-05 at 11 58 09 PM" src="https://github.com/user-attachments/assets/b4aeb8ff-fd50-45b1-ad67-89152dfd4f22" />

### Alerts
Scaled down controller to trigger alert.
<img width="1396" height="586" alt="Screenshot 2026-03-06 at 8 10 21 AM" src="https://github.com/user-attachments/assets/97f4de2f-50b1-412a-81c5-08e1cc9894df" />

### Grafana dashboard
Dashboard used: https://grafana.com/grafana/dashboards/20162-metallb/
<img width="1405" height="606" alt="Screenshot 2026-03-05 at 9 26 09 PM" src="https://github.com/user-attachments/assets/6ae497a9-f779-4108-b1b7-5ec0d7dbe61c" />
